### PR TITLE
allow targeted linkReplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ If installed by script tag, the methods are exposed through `window.loom`
 
 ## Methods
 
-### .linkReplace(selector, [options])
+### .linkReplace(selector, [options], target)
 
-Replaces any loom links at the nodes matching the selector with the embedded video
+Replaces any loom links at the nodes matching the selector with the embedded video. Replacement occurs on the entire document, or on the optional target DOM element.
 
 ### .textReplace(textString, [options])
 

--- a/src/sdk/linkReplace.js
+++ b/src/sdk/linkReplace.js
@@ -16,8 +16,8 @@ const injectVideo = (linkNode, embedString) => {
   linkNode.parentNode.insertBefore(embedNode, linkNode);
 };
 
-const linkReplace = (selector = 'a', options = {}) => {
-  const linkNodes = [...document.querySelectorAll(selector)];
+const linkReplace = (selector = 'a', options = {}, target = document) => {
+  const linkNodes = [...target.querySelectorAll(selector)];
 
   linkNodes
     .filter(isValidLinkNode)


### PR DESCRIPTION
linkReplace scans the entire page and replaces links, this works weird with React redraws/renders. I'm adding an option here to pass in a target, and only scan that - this seems to play nicely with a `ref` in React. 


here's a demo of why I want this:

https://www.loom.com/share/1554b40ab813430bb63dbc82a98cc95e